### PR TITLE
feat: mlock vault key

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "cuid2",
  "futures-io",
  "futures-util",
+ "region",
  "secrecy",
  "serde",
  "serde_cbor",
@@ -2422,6 +2423,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,6 +3613,18 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "reqwest"
@@ -5781,6 +5803,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ chrono = "0.4.42"
 tauri-specta = {version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
+region = "3.0.2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/store/commands.rs
+++ b/src-tauri/src/store/commands.rs
@@ -30,7 +30,7 @@ pub fn vault_unlocked(state: tauri::State<Mutex<AppState>>) -> bool {
         poisoned.into_inner()
     });
     if state.vault.is_none() {
-        return false
+        return false;
     }
     let vault = state
         .vault
@@ -64,7 +64,7 @@ pub async fn create_vault(password: String, app_handle: tauri::AppHandle) -> Res
     let vault_path = app_handle.path().app_data_dir().unwrap().join("vault.cb");
 
     let vault_location = vault_path.to_str().unwrap();
-    let vault = Vault::create_vault(vault_location, &password);
+    let vault = Vault::create_vault(vault_location, &password)?;
     vault.save_vault();
     Ok(())
 }


### PR DESCRIPTION
use the [region](https://darfink.github.io/region-rs/) crate to lock the vault key to memory, disallowing swap.

creates a new `_key_guard` field on the `Vault` object that will unlock the memory when dropped