### PR TITLE
feat: export to .txt files instead of .age files

### DIFF
--- a/src/components/KeyViewDialog.svelte
+++ b/src/components/KeyViewDialog.svelte
@@ -56,7 +56,7 @@
         }
 
         const destination = await save({
-            filters: [{ name: "age key file", extensions: ["age"] }],
+            filters: [{ name: "age key file", extensions: ["txt"] }],
         });
         if (!destination) {
             exportingKey = false;


### PR DESCRIPTION
avoids ambiguity between keys and actual age files

especially considering that "age file" likely doesn't include keys:
> age files MAY use the extension .age, in both their binary and [armored](https://github.com/C2SP/C2SP/blob/main/age.md#ascii-armor) formats.

(*[age-encryption.org/v1](https://github.com/C2SP/C2SP/blob/main/age.md#encrypted-file-format)*)